### PR TITLE
fix for unicode characters in "about" HTML

### DIFF
--- a/xbundle.py
+++ b/xbundle.py
@@ -166,7 +166,9 @@ class XBundle(object):
             about = etree.SubElement(self.metadata,'about')
         abfile = etree.SubElement(about, 'file')
         abfile.set('filename',filename)
-        abfile.text = filedata
+        # Unicode characters in the "about" HTML file were causing
+        # the lxml package to break.
+        abfile.text = filedata.decode('utf-8')
 
 
     #----------------------------------------


### PR DESCRIPTION
Fixes this issue.

A unicode character \u2019 (right single quotation mark) is in the "about" HTML file instead of an apostrophe in the word "you'd." This the package when inserting the contents of that HTML file as a string into `abfile.text` in `add_about_file`.

```
Converting edX xml directory '/tmp/content-devops-0001/' to xbundle file '/tmp/out.xml'
Traceback (most recent call last):
  File "xbundle.py", line 624, in <module>
    xb.import_from_directory(infn)
  File "xbundle.py", line 214, in import_from_directory
    self.import_metadata_from_directory(dir)
  File "xbundle.py", line 232, in import_metadata_from_directory
    self.add_about_file(os.path.basename(afn), open(afn).read())
  File "xbundle.py", line 169, in add_about_file
    abfile.text = filedata
  File "lxml.etree.pyx", line 951, in lxml.etree._Element.text.__set__ (src/lxml/lxml.etree.c:46353)
  File "apihelpers.pxi", line 695, in lxml.etree._setNodeText (src/lxml/lxml.etree.c:20953)
  File "apihelpers.pxi", line 683, in lxml.etree._createTextNode (src/lxml/lxml.etree.c:20829)
  File "apihelpers.pxi", line 1393, in lxml.etree._utf8 (src/lxml/lxml.etree.c:27125)
ValueError: All strings must be XML compatible: Unicode or ASCII, no NULL bytes or control characters
```