### PR TITLE
Fix bug with path separator.

### DIFF
--- a/xbundle.py
+++ b/xbundle.py
@@ -292,6 +292,8 @@ class XBundle(object):
         '''
         un = xml.get('url_name','')
         if xml.tag in self.DescriptorTags and 'url_name' in xml.attrib and un:
+            # Path separators are stored as colons in the XML.
+            un = un.replace(":", "/")
             dxml = etree.parse(dir / xml.tag / (un+'.xml')).getroot()
             dxml.attrib.update(xml.attrib)
             dxml.attrib.pop('url_name')


### PR DESCRIPTION
In this example, file `problem/P2/problem_1.xml` exists, but since the HTML contained `P2:` instead of `P2/`, lxml fails to locate the file.

```
Converting edX xml directory '/tmp/content-devops-0001/' to xbundle file '/tmp/out.xml'
Traceback (most recent call last):
  File "xbundle.py", line 624, in <module>
    xb.import_from_directory(infn)
  File "xbundle.py", line 215, in import_from_directory
    self.import_course_from_directory(dir)
  File "xbundle.py", line 240, in import_course_from_directory
    cxml = self.import_xml_removing_descriptor(dir, x)
  File "xbundle.py", line 335, in import_xml_removing_descriptor
    dchild = self.import_xml_removing_descriptor(dir, child)    # recurse
  File "xbundle.py", line 335, in import_xml_removing_descriptor
    dchild = self.import_xml_removing_descriptor(dir, child)    # recurse
  File "xbundle.py", line 335, in import_xml_removing_descriptor
    dchild = self.import_xml_removing_descriptor(dir, child)    # recurse
  File "xbundle.py", line 335, in import_xml_removing_descriptor
    dchild = self.import_xml_removing_descriptor(dir, child)    # recurse
  File "xbundle.py", line 295, in import_xml_removing_descriptor
    dxml = etree.parse(dir / xml.tag / (un+'.xml')).getroot()
  File "lxml.etree.pyx", line 3310, in lxml.etree.parse (src/lxml/lxml.etree.c:72517)
  File "parser.pxi", line 1791, in lxml.etree._parseDocument (src/lxml/lxml.etree.c:105979)
  File "parser.pxi", line 1817, in lxml.etree._parseDocumentFromURL (src/lxml/lxml.etree.c:106278)
  File "parser.pxi", line 1721, in lxml.etree._parseDocFromFile (src/lxml/lxml.etree.c:105277)
  File "parser.pxi", line 1122, in lxml.etree._BaseParser._parseDocFromFile (src/lxml/lxml.etree.c:100227)
  File "parser.pxi", line 580, in lxml.etree._ParserContext._handleParseResultDoc (src/lxml/lxml.etree.c:94350)
  File "parser.pxi", line 690, in lxml.etree._handleParseResult (src/lxml/lxml.etree.c:95786)
  File "parser.pxi", line 618, in lxml.etree._raiseParseError (src/lxml/lxml.etree.c:94818)
IOError: Error reading file '/tmp/content-devops-0001/problem/P2:problem_1.xml': failed to load external entity "/tmp/content-devops-0001/problem/P2:problem_1.xml"
```